### PR TITLE
Remove strtolower from readStdin function in dev installer

### DIFF
--- a/installers/php/dev_installer.php
+++ b/installers/php/dev_installer.php
@@ -20,9 +20,9 @@
 */
 function readStdin($prompt, $valid_inputs = false, $default = '') {
 	// Courtesy of http://us3.php.net/manual/en/features.commandline.io-streams.php#101307
-	while(!isset($input) || (is_array($valid_inputs) && !in_array(strtolower($input), $valid_inputs))) {
+	while(!isset($input) || (is_array($valid_inputs) && !in_array($input, $valid_inputs))) {
 		echo $prompt;
-		$input = strtolower(trim(fgets(STDIN)));
+		$input = trim(fgets(STDIN));
 		if(empty($input) && !empty($default)) {
 			$input = $default;
 		}


### PR DESCRIPTION
Currently readStdin runs strtolower() on everything it reads which is bad for passwords if they have uppercase characters.  I did a quick search and don't see anything that really needs strtolower() in this function, so I've removed it.  Let me know if you'd prefer making it optional with an argument.
