### PR TITLE
user_password is set below, this call causes a PHP notice

### DIFF
--- a/installers/php/dev_installer.php
+++ b/installers/php/dev_installer.php
@@ -92,7 +92,6 @@ echo "\n                       :+#\n"
 		$db_password    = readStdin('Database password: ');
 		
 		// set up database, add user / password
-		$user_password = substr(md5($system_salt . 'password'),4,7);
 		$db_port = 3306;
 		if (strpos($db_server,':') !== false) {
 			$host_and_port = explode(':',$db_server);


### PR DESCRIPTION
$system_salt is undefined at this point so it causes a PHP Notice.  Looks like this whole line is not needed/used anyway since the user stuff is set below.
