### PR TITLE
In docs, fix link to non-coder download

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@ hard to keep the requirements as minimal as possible:</p>
 <p>choosing SQLite will get you up and running fastest. Next just point Apache or MAMP 
 at the /DIY directory and view http://localhost/ in a browser.</p>
 
-<p>There's a web installer for non-coders <a href="https://github.com/cashmusic/DIY/downloads">here</a>.
+<p>There's a web installer for non-coders <a href="https://github.com/cashmusic/platform/downloads">here</a>.
 The idea is that we make it easy to deploy on any shared server. </p>
 
 	</div>


### PR DESCRIPTION
Old link didn't work (I'm guessing due to project rename).

I _think_ this is what it means to point to, but apologies if I'm wrong!
