### PR TITLE
allow hyphens in username, subdomain

### DIFF
--- a/interfaces/admin/components/pages/controllers/account.php
+++ b/interfaces/admin/components/pages/controllers/account.php
@@ -27,7 +27,7 @@ if (isset($_POST['doaccountchange'])) {
 		if (isset($_POST['new_username'])) { 
 			if ($_POST['new_username']) {
 				// strip all non-alpha/numeric and push it all to lowercase for the sake of uniqueness
-				$changes['username'] = strtolower(preg_replace("/[^a-z0-9]+/i", '',$_POST['new_username']));
+				$changes['username'] = strtolower(preg_replace("/[^a-z0-9-]+/i", '',$_POST['new_username']));
 			}
 		}
 		if (isset($_POST['new_displayname'])) { 


### PR DESCRIPTION
according to https://en.wikipedia.org/wiki/Uniform_Resource_Identifier and https://tools.ietf.org/html/rfc3986 a hyphen '-' is a legal URL character, which i am hoping is the reason why they were initially filtered out in the first place?  since the username is used as the subdomain for the cashmusic.org hosted single campaign page, for groups like ours whose name is 'in-giro' it becomes 'ingiro' w/o out this change.

this seemed like just a little change (i did not see a test for invalid usernames) and does not necessitate a big redux, though if you will accept this i could look into a bigger PR that allows all valid URL characters in username.

thanks.