### PR TITLE
use fulfillment asset cover art when creating a commerce item from release asset

### DIFF
--- a/framework/classes/plants/CommercePlant.php
+++ b/framework/classes/plants/CommercePlant.php
@@ -81,6 +81,26 @@ class CommercePlant extends PlantBase {
     ) {
         if (!$fulfillment_asset) {
             $digital_fulfillment = false;
+        } else {
+            // if there's no descriptive asset we can try pulling the cover from the fulfillment asset
+            if (empty($descriptive_asset)) {
+                $request = new CASHRequest(
+                    array(
+                        'cash_request_type' => 'asset',
+                        'cash_action' => 'getasset',
+                        'id' => $fulfillment_asset
+                    )
+                );
+
+                // we've got the request, we need to make sure the properties actually exist
+
+                $fulfillment_asset_data = $request->response['payload'];
+                if (is_array($fulfillment_asset_data['metadata'])
+                    && isset($fulfillment_asset_data['metadata']['cover'])
+                ) {
+                    $descriptive_asset = $fulfillment_asset_data['metadata']['cover'];
+                }
+            }
         }
         $result = $this->db->setData(
             'items',

--- a/interfaces/admin/components/pages/controllers/commerce_items_edit.php
+++ b/interfaces/admin/components/pages/controllers/commerce_items_edit.php
@@ -9,6 +9,7 @@ if (isset($_POST['doitemadd'])) {
 	if (isset($_POST['item_physical'])) {
 		$physical = 1;
 	}
+
 	$add_response = $cash_admin->requestAndStore(
 		array(
 			'cash_request_type' => 'commerce',


### PR DESCRIPTION
copies the fulfillment asset cover and assigns it to the descriptive asset, if $descriptive_asset is empty and $fulfillment_asset cover art is not. and stuff.