### PR TITLE
bulk email buyers by item hotfix

### DIFF
--- a/interfaces/admin/components/pages/controllers/commerce_items_edit.php
+++ b/interfaces/admin/components/pages/controllers/commerce_items_edit.php
@@ -73,6 +73,11 @@ if (isset($_POST['doitemadd'])) {
 				'include_download' => $include_download
 			)
 		);
+
+		error_log(
+			print_r($email_response, true)
+		);
+
 		if ($email_response['payload']) {
 			AdminHelper::formSuccess('Success. Email sent.');
 		} else {


### PR DESCRIPTION
bypassing mandrillseed until we rehash this whole process. uses CASHSystem::sendEmail in a loop right now, which isn't ideal... but it works.