### PR TITLE
Enable .htaccess support for Apache 2.4

### DIFF
--- a/interfaces/.htaccess
+++ b/interfaces/.htaccess
@@ -1,6 +1,16 @@
 RewriteEngine On
 RewriteBase /
-Options +FollowSymlinks
+<IfModule mod_version.c>
+	<IfVersion >= 2.4>
+		Options +SymlinksIfOwnerMatch
+	</IfVersion>
+	<IfVersion < 2.4>
+		Options +FollowSymlinks
+	</IfVersion>
+</IfModule>
+<IfModule !mod_version.c>
+		Options +FollowSymlinks
+</IfModule>
 Options -Indexes
 
 # COMPRESSION


### PR DESCRIPTION
This simple change enabled the .htaccess file to work on servers with Apache 2.4 and newer, while retaining compatability with older versions of Apache2.

If the detection between 2.4 and 2.2 cannot be made, it defaults to Apache 2.2 since a lot of shared hosting systems remain on this older version.